### PR TITLE
Support command to restart the mininet and an approach to push custom netcfg.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+#For container onos
+ONOS_APPS=drivers,openflow,segmentrouting,fpm,dhcprelay,routeradvertisement,hostprobingprovider,t3
+
+#For container start_onos
+TIMEOUT=120
+URL=http://onos:8181/onos/segmentrouting/xconnect --user onos:rocks
+
+# For container mininet
+CFG_PATH=/root/mininet/volume
+CFG_FILE=
+TOPO=trellis
+ONOS_HOSTNAME=onos

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean onos mininet host
+.PHONY: clean onos mininet host restasrt_mininet
 
 ALL:
 	@echo "\033[32m-------------\033[0m"
@@ -15,6 +15,10 @@ clean:
 
 onos:
 	ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null onos@localhost -p 18101
+
+restart_mininet:
+	sudo -E docker-compose rm -sf mininet
+	sudo -E docker-compose up -d --no-recreate mininet
 
 mininet:
 	@echo "\033[31m---------------------------------------------------------------\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -4,28 +4,28 @@ ALL:
 	@echo "\033[32m-------------\033[0m"
 	@echo "\033[32mStarting ONOS\033[0m"
 	@echo "\033[32m-------------\033[0m"
-	sudo -E docker-compose run --rm start_onos
+	docker-compose run --rm start_onos
 	@echo "\033[32m----------------\033[0m"
 	@echo "\033[32mStarting Mininet\033[0m"
 	@echo "\033[32m----------------\033[0m"
-	sudo -E docker-compose up -d mininet
+	docker-compose up -d mininet
 
 clean:
-	sudo -E docker-compose down --remove-orphan
+	docker-compose down --remove-orphan
 
 onos:
 	ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null onos@localhost -p 18101
 
 restart_mininet:
-	sudo -E docker-compose rm -sf mininet
-	sudo -E docker-compose up -d --no-recreate mininet
+	docker-compose rm -sf mininet
+	docker-compose up -d --no-recreate mininet
 
 mininet:
 	@echo "\033[31m---------------------------------------------------------------\033[0m"
 	@echo "\033[31mCaution:\033[0m"
 	@echo "\033[31mCtrl-D will terminate mininet. Use Ctrl-P then Ctrl-Q to escape\033[0m"
 	@echo "\033[31m---------------------------------------------------------------\033[0m"
-	sudo -E docker attach mininet || true
+	docker attach mininet || true
 
 host:
-	sudo -E docker exec -it mininet /root/m $(HOST)
+	docker exec -it mininet /root/m $(HOST)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The script will automatically start a single instance ONOS, push corresponding n
 We assume you have Docker installed in your system. We recommend using Docker >= 18.06.
 For Docker on Mac users, remember to add `tiab/volume/onos` to shared folder list.
 
-Please make sure your user be able to run the docker command or use `sudo` for the folowing commands.
+Please make sure your user be able to run the docker command or use `sudo` for the following commands.
 
 ## Quick Start
 
@@ -98,10 +98,12 @@ Please make sure your user be able to run the docker command or use `sudo` for t
 
 - netcfg
 
-    The mininet container will push the `${TOPO}`.json to ONOS controller by default, and you can override this behavior by providing your config file.
-    - Place your file under `volume/mininet` and replace the environment variable `CFG_FILE` in `.env` file with your file name.
-    - Restart the mininet by the command `make restart_mininet` and then check the log by running `docker logs -f mininet | grep "Check custom config"`
-    - If the file you provided doesn't exist, it will roll back to push the netcfg `${TOPO}`.json to ONOS.
+    The mininet container will push the netcfg to ONOS controller during the booting up process and the netcfg file comes from two ways.
+    1. Default configuration file, will be `${TOPO}.json`.
+    1. User defined configuration file, refer to thee following steps to override the default behavior.
+      - Place your file under `volume/mininet` and replace the environment variable `CFG_FILE` in `.env` file with your file name.
+      - Restart the mininet by the command `make restart_mininet` and then check the log by running `docker logs -f mininet | grep "Check custom config"`
+      - If the file you provided doesn't exist or it's invalid file, the mininet container will abort.
 
 ## Reference
 - [1] [Trellis documentation](https://docs.trellisfabric.org)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The script will automatically start a single instance ONOS, push corresponding n
 We assume you have Docker installed in your system. We recommend using Docker >= 18.06.
 For Docker on Mac users, remember to add `tiab/volume/onos` to shared folder list.
 
+Please make sure your user be able to run the docker command or use `sudo` for the folowing commands.
+
 ## Quick Start
 
 - Download TiaB
@@ -41,6 +43,11 @@ For Docker on Mac users, remember to add `tiab/volume/onos` to shared folder lis
 - Attach to a host in Mininet
     ```
     make host HOST=h1
+    ```
+
+- Restart a Mininet
+    ```
+    make restart_mininet
     ```
 
 - Tear down TiaB
@@ -79,7 +86,7 @@ For Docker on Mac users, remember to add `tiab/volume/onos` to shared folder lis
     - `trellis_remote_dhcp`: with remote DHCP server
     - `trellis_hag`: multiple stage fabric. This is the **most complete topology**
 
-    **To use another topology, search for an environment variable `TOPO` in `docker-compose.yaml` and replace it with desired value.**
+    **To use another topology, search for an environment variable `TOPO` in `.env` and replace it with desired value.**
 
     There are another 3 that requires BMV2, and therefore does **not** work in this environment.
     - `trellis_hybrid`
@@ -88,6 +95,13 @@ For Docker on Mac users, remember to add `tiab/volume/onos` to shared folder lis
 
     Double VLAN pop and route is no longer supported with OVS. We have moved forward to implementing that with P4 BNG. Therefore the follow one doesn't work either.
     - `trellis_double_tagged`
+
+- netcfg
+
+    The mininet container will push the `${TOPO}`.json to ONOS controller by default, and you can override this behavior by providing your config file.
+    - Place your file under `volume/mininet` and replace the environment variable `CFG_FILE` in `.env` file with your file name.
+    - Restart the mininet by the command `make restart_mininet` and then check the log by running `docker logs -f mininet | grep "Check custom config"`
+    - If the file you provided doesn't exist, it will roll back to push the netcfg `${TOPO}`.json to ONOS.
 
 ## Reference
 - [1] [Trellis documentation](https://docs.trellisfabric.org)

--- a/README.md
+++ b/README.md
@@ -96,14 +96,15 @@ Please make sure your user be able to run the docker command or use `sudo` for t
     Double VLAN pop and route is no longer supported with OVS. We have moved forward to implementing that with P4 BNG. Therefore the follow one doesn't work either.
     - `trellis_double_tagged`
 
-- netcfg
+- Network Configurations (netcfg)
 
-    The mininet container will push the netcfg to ONOS controller during the booting up process and the netcfg file comes from two ways.
-    1. Default configuration file, will be `${TOPO}.json`.
-    1. User defined configuration file, refer to thee following steps to override the default behavior.
-      - Place your file under `volume/mininet` and replace the environment variable `CFG_FILE` in `.env` file with your file name.
-      - Restart the mininet by the command `make restart_mininet` and then check the log by running `docker logs -f mininet | grep "Check custom config"`
-      - If the file you provided doesn't exist or it's invalid file, the mininet container will abort.
+    The Mininet container will push the netcfg to ONOS controller during the start up process.
+    For each topology `${TOPO}`, a corresponding netcfg `${TOPO}.json` will be loaded by default.
+    We can also provide a customized netcfg to override the default one. It can be done by following steps.
+
+      - Place your netcfg file under `volume/mininet` and replace the environment variable `CFG_FILE` in `.env` with your netcfg file name.
+      - Restart the Mininet by the command `make restart_mininet`. You can verify whether the customized netcfg is loaded or not by running `docker logs -f mininet | grep "Check custom config"`
+      - If `CFG_FILE` is specified but the file doesn't exist or is invalid, the Mininet container will abort.
 
 ## Reference
 - [1] [Trellis documentation](https://docs.trellisfabric.org)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     env_file:
       - .env
     environment:
-      - CUSTOM_CFG=${CFG_PATH}/${CFG_FILE}
+      - NETCFG=${CFG_PATH}/${CFG_FILE}
     networks:
       - mgmt
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
     image: charlesmcchan/onos:20191022
     container_name: onos
     privileged: true
+    env_file:
+      - .env
     environment:
       - ONOS_APPS=drivers,openflow,segmentrouting,fpm,dhcprelay,routeradvertisement,hostprobingprovider,t3
     volumes:
@@ -21,9 +23,8 @@ services:
     image: stefanevinance/wait-for-200
     depends_on:
       - onos
-    environment:
-      - TIMEOUT=120
-      - URL=http://onos:8181/onos/segmentrouting/xconnect --user onos:rocks
+    env_file:
+      - .env
     networks:
       - mgmt
 
@@ -31,11 +32,14 @@ services:
     image: charlesmcchan/mn-trellis:20191022
     container_name: mininet
     privileged: true
+    volumes:
+      - "./volume/mininet:${CFG_PATH}"
     depends_on:
       - start_onos
+    env_file:
+      - .env
     environment:
-      - ONOS_HOSTNAME=onos
-      - TOPO=trellis
+      - CUSTOM_CFG=${CFG_PATH}/${CFG_FILE}
     networks:
       - mgmt
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,8 @@ services:
     env_file:
       - .env
     environment:
-      - NETCFG=${CFG_PATH}/${CFG_FILE}
+      - EXTERNAL_VOLUME=${CFG_PATH}
+      - NETCFG_FILE=${CFG_FILE}
     networks:
       - mgmt
     tty: true


### PR DESCRIPTION
For issue #1 
1. Remove the sudo command from the Makefile, the user should handle the execution permission.
2. Add the makefile command to restart the mininet.
3. Replace the environment by env files so that we can use the environment variable in docker-compose.yml. it's helpful if there are some duplicated values. 
4. Push customized netcfg by placing the file under `/volume/mininet` and modify the environment variable `CFG_FILE` in `.env`.

We should wait for [patch](https://gerrit.onosproject.org/22743) first and then replace the mininet container image with new one in `docker-compose.yml`.